### PR TITLE
[FEAT] 노드 내용 수정 기능 구현 및 실시간 동기화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ CLAUDE.md
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+docs/

--- a/src/features/editor/NotionEditor.tsx
+++ b/src/features/editor/NotionEditor.tsx
@@ -70,7 +70,7 @@ type BlockType =
 export interface NotionEditorProps {
   nodeId: string;
   initialContent?: string;
-  onSave?: (nodeId: string, content: string) => void;
+  onSave?: (nodeId: string, jsonBody: string, markdownBody: string) => void;
 }
 
 // ─── Image Node ───────────────────────────────────────────────────────────────
@@ -608,11 +608,11 @@ export function NotionEditor({
   const handleChange = useCallback(
     (editorState: EditorState) => {
       const json = JSON.stringify(editorState.toJSON(), null, 2);
+      let markdown = "";
       editorState.read(() => {
-        const markdown = $convertToMarkdownString(TRANSFORMERS);
-        console.log(`[NotionEditor:${nodeId}] markdown:\n`, markdown);
+        markdown = $convertToMarkdownString(TRANSFORMERS);
       });
-      onSave?.(nodeId, json);
+      onSave?.(nodeId, json, markdown);
     },
     [nodeId, onSave],
   );

--- a/src/features/graph/api/mappers.ts
+++ b/src/features/graph/api/mappers.ts
@@ -10,6 +10,7 @@ export function toFlowNode(dto: NodeDto): Node {
     position: { x: dto.position_x, y: dto.position_y },
     data: {
       text: dto.title,
+      content: dto.content?.jsonBody ?? undefined,
       body: dto.content?.markdownBody ?? "",
       isMain: dto.node_type === "PROJECT",
       color: dto.content?.color ?? DEFAULT_NODE_COLOR.bg,

--- a/src/features/graph/components/GraphCanvas.tsx
+++ b/src/features/graph/components/GraphCanvas.tsx
@@ -27,7 +27,7 @@ import * as d3 from "d3";
 import { nodeTypes } from "@/types/nodeTypes";
 import { edgeTypes } from "@/types/edgeTypes";
 import { getNodes } from "../api/getNodes";
-import { createMdNode, moveNode, deleteNode } from "../api/nodes";
+import { createMdNode, moveNode, deleteNode, updateNodeContent } from "../api/nodes";
 import { emitLivePosition, emitCursorMove } from "@/api/ws";
 import { createEdge } from "../api/edges";
 import type { EdgeDto, NodeDto } from "../types";
@@ -642,6 +642,9 @@ function GraphCanvasInner({
   const simulationRef = useRef<d3.Simulation<D3Node, undefined> | null>(null);
   const d3NodesRef = useRef<D3Node[]>([]);
   const isDraggingRef = useRef(false);
+  const nodesRef = useRef<Node[]>(nodes);
+  nodesRef.current = nodes;
+  const contentSaveTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
   const [isGrabbing, setIsGrabbing] = useState(false);
   const [isHoveringNode, setIsHoveringNode] = useState(false);
   const previousDragPositionRef = useRef<{ x: number; y: number } | null>(null);
@@ -683,6 +686,14 @@ function GraphCanvasInner({
     document.addEventListener('pointermove', handler);
     return () => document.removeEventListener('pointermove', handler);
   }, []); // 마운트/언마운트 시 1회만 등록 — 최신 값은 ref로 접근
+
+  // contentSaveTimers cleanup on unmount
+  useEffect(() => {
+    return () => {
+      contentSaveTimers.current.forEach((timer) => clearTimeout(timer));
+      contentSaveTimers.current.clear();
+    };
+  }, []);
 
   /* =========================
      D3 Force Simulation 초기화
@@ -775,8 +786,26 @@ function GraphCanvasInner({
         isHovered: hoveredNodeId === node.id, // 드래그 중 hover된 노드 표시
         onChange: (nodeId: string, value: string) =>
           handleNodeDataChange(nodeId, { text: value }),
-        onContentChange: (nodeId: string, content: string) =>
-          handleNodeDataChange(nodeId, { content }),
+        onContentChange: (nodeId: string, jsonBody: string, markdownBody: string) => {
+          handleNodeDataChange(nodeId, { content: jsonBody });
+
+          const prev = contentSaveTimers.current.get(nodeId);
+          if (prev) clearTimeout(prev);
+          contentSaveTimers.current.set(
+            nodeId,
+            setTimeout(() => {
+              const currentNode = nodesRef.current.find((n) => n.id === nodeId);
+              updateNodeContent(workspaceId, nodeId, {
+                body: {
+                  jsonBody,
+                  markdownBody,
+                  color: (currentNode?.data?.color as string) ?? "#ffffff",
+                  textColor: (currentNode?.data?.textColor as string) ?? "#000000",
+                },
+              }).catch(console.error);
+            }, 800),
+          );
+        },
       },
     };
   });

--- a/src/features/nodes/TextUpdateNode.tsx
+++ b/src/features/nodes/TextUpdateNode.tsx
@@ -41,7 +41,7 @@ export type NodeData = {
   showInputBox?: boolean; // 입력박스 표시 여부
   isHovered?: boolean; // 드래그 중 hover 상태
   onChange?: (nodeId: string, value: string) => void;
-  onContentChange?: (nodeId: string, content: string) => void; // 에디터 내용 저장 콜백
+  onContentChange?: (nodeId: string, jsonBody: string, markdownBody: string) => void; // 에디터 내용 저장 콜백
 };
 
 export function TextUpdaterNode({ data, id }: NodeProps) {

--- a/src/hooks/useWorkspaceWS.ts
+++ b/src/hooks/useWorkspaceWS.ts
@@ -173,6 +173,9 @@ export function useWorkspaceWS({
               data: {
                 ...updated.data,
                 ...(e.patch.title !== undefined && { text: e.patch.title }),
+                ...(e.patch.data?.jsonBody !== undefined && {
+                  content: e.patch.data.jsonBody,
+                }),
                 ...(e.patch.data?.markdownBody !== undefined && {
                   body: e.patch.data.markdownBody,
                 }),


### PR DESCRIPTION

## Summary

- 노드 내용 수정 시 `markdownBody` 추가 및 debounce 기반 서버 저장 연동
- 노드 로드 및 WS 업데이트 시 `jsonBody`가 `data.content`에 반영되지 않던 버그 수정
- `.gitignore` 업데이트

## Changes

- `mappers.ts`: `data.content` 매핑 로직 추가
- `GraphCanvas.tsx`: 노드 업데이트 WS 이벤트 처리 개선
- `TextUpdateNode.tsx`: markdownBody 연동
- `useWorkspaceWS.ts`: WS 수신 시 content 반영 처리

## Test plan

- [X] 노드 텍스트 수정 후 일정 시간 경과 시 서버에 저장되는지 확인
- [X] WS로 다른 클라이언트 업데이트 수신 시 `data.content` 정상 반영 확인
- [X] 노드 새로고침 후 수정된 내용 유지 확인

## 추가 구현 사항

에디터를 열면 다른 사용자에게도 보이도록 구현 - 보이게할지 말지
같은 노드를 동시 편집할때 - CIDR 구현 준비
노드 편집시 커서 모양 변경


