### PR TITLE
fix: 엣지 핸들 ID 불일치 및 노드 연결 방향 로직 수정

### DIFF
--- a/src/features/graph/components/GraphCanvas.tsx
+++ b/src/features/graph/components/GraphCanvas.tsx
@@ -26,7 +26,6 @@ import "@xyflow/react/dist/style.css";
 import * as d3 from "d3";
 import { nodeTypes } from "@/types/nodeTypes";
 import { edgeTypes } from "@/types/edgeTypes";
-import { getNodes } from "../api/getNodes";
 import { createMdNode, moveNode, deleteNode } from "../api/nodes";
 import { emitLivePosition, emitCursorMove } from "@/api/ws";
 import { createEdge } from "../api/edges";
@@ -101,10 +100,15 @@ function getGraphColor(
       .map((e) => nodes.find((n) => n.id === e.target))
       .filter((n): n is Node => n !== undefined);
 
-    if (children.length > 0 && children[0].data?.color) {
+    // 기본 색상이 아닌 커스텀 색상을 가진 첫 번째 자식의 색상을 사용
+    const coloredChild = children.find((child) =>
+      isCustomColorNode(child.id, nodes),
+    );
+    if (coloredChild) {
       return {
-        bg: children[0].data.color as string,
-        text: (children[0].data.textColor as string) || DEFAULT_NODE_COLOR.text,
+        bg: coloredChild.data.color as string,
+        text:
+          (coloredChild.data.textColor as string) || DEFAULT_NODE_COLOR.text,
       };
     }
 
@@ -119,19 +123,6 @@ function getGraphColor(
   }
 
   return getRandomColorPair();
-}
-
-function isStandaloneNode(
-  nodeId: string,
-  nodes: Node[],
-  edges: Edge[],
-): boolean {
-  const node = nodes.find((n) => n.id === nodeId);
-  if (!node || node.data?.isMain) return false;
-
-  const hasParent = getParentId(nodeId, edges) !== null;
-  const hasChildren = edges.some((edge) => edge.source === nodeId);
-  return !hasParent && !hasChildren;
 }
 
 function isCustomColorNode(nodeId: string, nodes: Node[]): boolean {
@@ -324,10 +315,6 @@ function findNonOverlappingPosition(
   return base;
 }
 
-function getHandleSide(node: Node, referenceX: number): "left" | "right" {
-  return node.position.x < referenceX ? "left" : "right";
-}
-
 function getForcedOutboundSideForSubNodeInMainGraph(
   node: Node,
   nodes: Node[],
@@ -345,7 +332,7 @@ function getForcedOutboundSideForSubNodeInMainGraph(
   const referenceX = parentNode?.position.x ?? mainNode.position.x;
 
   // main(또는 parent) 쪽의 반대 방향(바깥쪽)으로만 새 연결을 허용
-  return getHandleSide(node, referenceX);
+  return getTargetSideRelativeToParent(node.position.x, referenceX);
 }
 
 function resolveConnectSideFromSource(
@@ -365,7 +352,10 @@ function resolveConnectSideFromSource(
   if (sourceHandle?.includes("left")) return "left";
   if (sourceHandle?.includes("right")) return "right";
 
-  return getEdgeSide(sourceNode, targetNode);
+  return getTargetSideRelativeToParent(
+    targetNode.position.x,
+    sourceNode.position.x,
+  );
 }
 
 function resolveSideFromEdgeHandle(
@@ -376,11 +366,17 @@ function resolveSideFromEdgeHandle(
   if (edge.sourceHandle?.includes("left")) return "left";
   if (edge.sourceHandle?.includes("right")) return "right";
 
-  return getEdgeSide(sourceNode, targetNode);
+  return getTargetSideRelativeToParent(
+    targetNode.position.x,
+    sourceNode.position.x,
+  );
 }
 
-function getEdgeSide(source: Node, target: Node): "left" | "right" {
-  return target.position.x < source.position.x ? "left" : "right";
+function getTargetSideRelativeToParent(
+  targetX: number,
+  parentX: number,
+): "left" | "right" {
+  return targetX < parentX ? "left" : "right";
 }
 
 /**
@@ -418,11 +414,7 @@ function adjustPositionRelativeToSource(
       if (!targetNode) return null;
       return {
         node: targetNode,
-        edgeSide: resolveSideFromEdgeHandle(
-          edge,
-          sourceNode,
-          targetNode,
-        ),
+        edgeSide: resolveSideFromEdgeHandle(edge, sourceNode, targetNode),
       };
     })
     .filter(
@@ -460,12 +452,15 @@ function adjustPositionRelativeToSource(
 }
 
 function resolveHandleId(
-  _node: Node,
   role: "source" | "target",
   side: "left" | "right",
-  _edges: Edge[],
 ): string {
-  return `${role}-${side}`;
+  // source 핸들: side 방향 (예: side="right" → source-right)
+  // target 핸들: source의 반대 방향 (예: side="right"이면 target이 source 오른쪽에 있으므로 → target-left)
+  if (role === "target") {
+    return `target-${side === "left" ? "right" : "left"}`;
+  }
+  return `source-${side}`;
 }
 
 function buildEdgePresentation(edge: Edge, nodes: Node[], edges: Edge[]): Edge {
@@ -478,9 +473,11 @@ function buildEdgePresentation(edge: Edge, nodes: Node[], edges: Edge[]): Edge {
     nodes,
     edges,
   );
-  const side = forcedSourceSide ?? getEdgeSide(source, target);
-  const sourceHandle = resolveHandleId(source, "source", side, edges);
-  const targetHandle = resolveHandleId(target, "target", side, edges);
+  const side =
+    forcedSourceSide ??
+    getTargetSideRelativeToParent(target.position.x, source.position.x);
+  const sourceHandle = resolveHandleId("source", side);
+  const targetHandle = resolveHandleId("target", side);
   const sourceHandleX =
     source.position.x +
     (side === "right"
@@ -605,7 +602,10 @@ export function convertToReactFlow(
       ...node,
       data: {
         ...node.data,
-        handleSide: getHandleSide(node, parentNode.position.x),
+        handleSide: getTargetSideRelativeToParent(
+          node.position.x,
+          parentNode.position.x,
+        ),
         hasParent: true,
       },
     };
@@ -651,7 +651,9 @@ function GraphCanvasInner({
 
   // ─── Cursor sharing ──────────────────────────────────────
   const remoteCursors = useCursors(workspaceId);
-  const [selfCursor, setSelfCursor] = useState<import("@/api/ws").CursorPayload | null>(null);
+  const [selfCursor, setSelfCursor] = useState<
+    import("@/api/ws").CursorPayload | null
+  >(null);
   const lastCursorEmitRef = useRef(0);
   const CURSOR_EMIT_INTERVAL = 30; // ms
   const cursorColor = getCursorColor(currentUserId);
@@ -664,24 +666,50 @@ function GraphCanvasInner({
   // document 레벨 pointermove — 드래그/모든 마우스 동작에서도 동작
   const screenToFlowPositionRef = useRef(screenToFlowPosition);
   screenToFlowPositionRef.current = screenToFlowPosition;
-  const cursorMetaRef = useRef({ workspaceId, currentUserId, currentUserName, cursorColor });
-  cursorMetaRef.current = { workspaceId, currentUserId, currentUserName, cursorColor };
+  const cursorMetaRef = useRef({
+    workspaceId,
+    currentUserId,
+    currentUserName,
+    cursorColor,
+  });
+  cursorMetaRef.current = {
+    workspaceId,
+    currentUserId,
+    currentUserName,
+    cursorColor,
+  };
 
   useEffect(() => {
     const handler = (event: PointerEvent) => {
-      const { workspaceId, currentUserId, currentUserName, cursorColor } = cursorMetaRef.current;
-      const flowPos = screenToFlowPositionRef.current({ x: event.clientX, y: event.clientY });
+      const { workspaceId, currentUserId, currentUserName, cursorColor } =
+        cursorMetaRef.current;
+      const flowPos = screenToFlowPositionRef.current({
+        x: event.clientX,
+        y: event.clientY,
+      });
 
-      setSelfCursor({ userId: currentUserId, x: flowPos.x, y: flowPos.y, userName: currentUserName, color: cursorColor });
+      setSelfCursor({
+        userId: currentUserId,
+        x: flowPos.x,
+        y: flowPos.y,
+        userName: currentUserName,
+        color: cursorColor,
+      });
 
       const now = Date.now();
       if (now - lastCursorEmitRef.current < CURSOR_EMIT_INTERVAL) return;
       lastCursorEmitRef.current = now;
-      emitCursorMove(workspaceId, flowPos.x, flowPos.y, currentUserName, cursorColor);
+      emitCursorMove(
+        workspaceId,
+        flowPos.x,
+        flowPos.y,
+        currentUserName,
+        cursorColor,
+      );
     };
 
-    document.addEventListener('pointermove', handler);
-    return () => document.removeEventListener('pointermove', handler);
+    document.addEventListener("pointermove", handler);
+    return () => document.removeEventListener("pointermove", handler);
   }, []); // 마운트/언마운트 시 1회만 등록 — 최신 값은 ref로 접근
 
   /* =========================
@@ -769,7 +797,7 @@ function GraphCanvasInner({
         ...node.data,
         handleSide: node.data?.isMain
           ? undefined
-          : getHandleSide(node, referenceX),
+          : getTargetSideRelativeToParent(node.position.x, referenceX),
         hasParent, // 부모 노드 존재 여부 전달
         showInputBox: selectedNodeId === node.id, // 선택된 노드에만 입력박스 표시
         isHovered: hoveredNodeId === node.id, // 드래그 중 hover된 노드 표시
@@ -1002,21 +1030,16 @@ function GraphCanvasInner({
     (params: Connection) => {
       if (!params.source || !params.target) return;
 
-      const sourceStandalone = isStandaloneNode(params.source, nodes, edges);
-      const targetStandalone = isStandaloneNode(params.target, nodes, edges);
-      const shouldAttachStandaloneToGraph =
-        sourceStandalone !== targetStandalone;
+      const sourceNode = nodes.find((n) => n.id === params.source);
+      const targetNode = nodes.find((n) => n.id === params.target);
+      const sourceIsMain = sourceNode?.data?.isMain === true;
+      const targetIsMain = targetNode?.data?.isMain === true;
 
-      const sourceId = shouldAttachStandaloneToGraph
-        ? sourceStandalone
-          ? params.target
-          : params.source
-        : params.source;
-      const targetId = shouldAttachStandaloneToGraph
-        ? sourceStandalone
-          ? params.source
-          : params.target
-        : params.target;
+      // main 노드가 포함된 경우에만 swap: main 노드가 항상 source(부모)가 되도록 강제
+      const shouldSwap = (sourceIsMain || targetIsMain) && !sourceIsMain;
+
+      const sourceId = shouldSwap ? params.target : params.source;
+      const targetId = shouldSwap ? params.source : params.target;
 
       // 연결된 target 노드 위치(및 subtree)와 색상을 source 기준으로 업데이트
       setNodes((currentNodes) => {
@@ -1066,11 +1089,7 @@ function GraphCanvasInner({
         const sourceHasCustomColor = isCustomColorNode(sourceId, currentNodes);
         const targetHasCustomColor = isCustomColorNode(targetId, currentNodes);
 
-        if (
-          !shouldAttachStandaloneToGraph &&
-          sourceHasCustomColor &&
-          targetHasCustomColor
-        ) {
+        if (!shouldSwap && sourceHasCustomColor && targetHasCustomColor) {
           return positionedNodes;
         }
 
@@ -1088,22 +1107,42 @@ function GraphCanvasInner({
       const swapped = sourceId !== params.source;
       const srcNode = nodes.find((n) => n.id === sourceId);
       const tgtNode = nodes.find((n) => n.id === targetId);
-      const fallbackSide = srcNode && tgtNode ? getEdgeSide(srcNode, tgtNode) : "right";
-      const resolvedSourceHandle = (swapped ? params.targetHandle : params.sourceHandle) ?? `source-${fallbackSide}`;
-      const resolvedTargetHandle = (swapped ? params.sourceHandle : params.targetHandle) ?? `target-${fallbackSide}`;
+      //Q: 이 부분 동작 무엇? fallback은 뭘 의미? resolvedSourceHandle은 무슨 뜻? swapped는 무슨 뜻?
+      const targetNodeSideRelativeToParent =
+        srcNode && tgtNode
+          ? getTargetSideRelativeToParent(
+              tgtNode.position.x,
+              srcNode.position.x,
+            )
+          : "right";
+      const resolvedSourceHandle =
+        (swapped ? params.targetHandle : params.sourceHandle) ??
+        `source-${targetNodeSideRelativeToParent}`;
+      const resolvedTargetHandle =
+        (swapped ? params.sourceHandle : params.targetHandle) ??
+        `target-${targetNodeSideRelativeToParent === "left" ? "right" : "left"}`;
       createEdge(
         workspaceId,
         sourceId,
         targetId,
         resolvedSourceHandle,
         resolvedTargetHandle,
-      ).then(({ edgeId }) => {
-        setEdges((snapshot) => {
-          if (snapshot.some((e) => e.id === edgeId)) return snapshot;
-          const rawEdge: Edge = { id: edgeId, source: sourceId, target: targetId };
-          return [...snapshot, buildEdgePresentation(rawEdge, nodes, [...snapshot, rawEdge])];
-        });
-      }).catch((err) => console.error("[createEdge] failed", err));
+      )
+        .then(({ edgeId }) => {
+          setEdges((snapshot) => {
+            if (snapshot.some((e) => e.id === edgeId)) return snapshot;
+            const rawEdge: Edge = {
+              id: edgeId,
+              source: sourceId,
+              target: targetId,
+            };
+            return [
+              ...snapshot,
+              buildEdgePresentation(rawEdge, nodes, [...snapshot, rawEdge]),
+            ];
+          });
+        })
+        .catch((err) => console.error("[createEdge] failed", err));
     },
     [nodes, edges, workspaceId],
   );
@@ -1159,7 +1198,10 @@ function GraphCanvasInner({
           const mainNode = getMainNodeForSubtree(sourceNode.id, nodes, edges);
           const referenceX =
             parentNode?.position.x ?? mainNode?.position.x ?? 0;
-          side = getHandleSide(sourceNode, referenceX);
+          side = getTargetSideRelativeToParent(
+            sourceNode.position.x,
+            referenceX,
+          );
         }
 
         // source 노드 기준으로 적절한 거리에 위치 조정
@@ -1184,7 +1226,12 @@ function GraphCanvasInner({
             workspaceId,
             "새 노드",
             adjustedPosition,
-            { markdownBody: "", jsonBody: "", color : colorPair.bg, textColor : colorPair.bg }
+            {
+              markdownBody: "",
+              jsonBody: "",
+              color: colorPair.bg,
+              textColor: colorPair.text,
+            },
           );
 
           // 실제 UUID로 로컬 노드 추가
@@ -1197,6 +1244,8 @@ function GraphCanvasInner({
               isMain: false,
               color: colorPair.bg,
               textColor: colorPair.text,
+              hasParent: true,
+              sideRelativeToParent: side,
             },
           };
 
@@ -1210,7 +1259,7 @@ function GraphCanvasInner({
             connectionState.fromNode.id,
             realNodeId,
             fromHandle || `source-${side}`,
-            `target-${side}`,
+            `target-${side === "left" ? "right" : "left"}`,
           );
           setEdges((eds) => {
             if (eds.some((e) => e.id === edgeId)) return eds;
@@ -1219,7 +1268,14 @@ function GraphCanvasInner({
               source: connectionState.fromNode.id,
               target: realNodeId,
             };
-            return [...eds, buildEdgePresentation(rawEdge, [...nodes, newNode], [...eds, rawEdge])];
+            return [
+              ...eds,
+              buildEdgePresentation(
+                rawEdge,
+                [...nodes, newNode],
+                [...eds, rawEdge],
+              ),
+            ];
           });
         } catch (err) {
           console.error("[onConnectEnd] node/edge creation failed", err);
@@ -1266,14 +1322,14 @@ function GraphCanvasInner({
       });
 
       try {
-        const body = { markdownBody: "", jsonBody: "", color : DEFAULT_NODE_COLOR.bg, textColor : DEFAULT_NODE_COLOR.bg } as MdBody
+        const body = {
+          markdownBody: "",
+          jsonBody: "",
+          color: DEFAULT_NODE_COLOR.bg,
+          textColor: DEFAULT_NODE_COLOR.bg,
+        } as MdBody;
 
-        const { nodeId } = await createMdNode(
-          workspaceId, 
-          "", 
-          position,
-          body
-          );
+        const { nodeId } = await createMdNode(workspaceId, "", position, body);
 
         const newNode: Node = {
           id: nodeId,
@@ -1614,7 +1670,7 @@ function GraphCanvasInner({
           );
 
           // 2. 연결 방향 결정
-          const side = resolveConnectSideFromSource(
+          const sideRelativeToParent = resolveConnectSideFromSource(
             parentNode,
             childNode,
             undefined,
@@ -1626,7 +1682,7 @@ function GraphCanvasInner({
           const adjustedPosition = adjustPositionRelativeToSource(
             parentNode,
             childNode.position.y,
-            side,
+            sideRelativeToParent,
             nodes,
             edges,
             childNode.id,
@@ -1674,7 +1730,7 @@ function GraphCanvasInner({
               ) / childNodes.length;
 
             const needsMirror =
-              side === "right"
+              sideRelativeToParent === "right"
                 ? avgChildCenterX < adjustedCenterX
                 : avgChildCenterX > adjustedCenterX;
 
@@ -1703,15 +1759,26 @@ function GraphCanvasInner({
             workspaceId,
             newParent.id,
             draggedNode.id,
-            `source-${side}`,
-            `target-${side}`,
-          ).then(({ edgeId }) => {
-            setEdges((prev) => {
-              if (prev.some((e) => e.id === edgeId)) return prev;
-              const rawEdge: Edge = { id: edgeId, source: newParent.id, target: draggedNode.id };
-              return [...prev, buildEdgePresentation(rawEdge, nodes, [...prev, rawEdge])];
-            });
-          }).catch((err) => console.error("[createEdge re-parent] failed", err));
+            `source-${sideRelativeToParent}`,
+            `target-${sideRelativeToParent === "left" ? "right" : "left"}`,
+          )
+            .then(({ edgeId }) => {
+              setEdges((prev) => {
+                if (prev.some((e) => e.id === edgeId)) return prev;
+                const rawEdge: Edge = {
+                  id: edgeId,
+                  source: newParent.id,
+                  target: draggedNode.id,
+                };
+                return [
+                  ...prev,
+                  buildEdgePresentation(rawEdge, nodes, [...prev, rawEdge]),
+                ];
+              });
+            })
+            .catch((err) =>
+              console.error("[createEdge re-parent] failed", err),
+            );
 
           // 7. childNode 서브트리 색상을 parentNode 색상으로 업데이트
           setNodes((currentNodes) => {
@@ -1854,7 +1921,12 @@ function GraphCanvasInner({
         connectionMode={ConnectionMode.Loose}
         connectionLineType={ConnectionLineType.SmoothStep}
       />
-      <CursorOverlay cursors={cursors} currentUserId={currentUserId} isGrabbing={isGrabbing} isHoveringNode={isHoveringNode} />
+      <CursorOverlay
+        cursors={cursors}
+        currentUserId={currentUserId}
+        isGrabbing={isGrabbing}
+        isHoveringNode={isHoveringNode}
+      />
       {isArchiveModalOpen && (
         <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/40">
           <div className="w-[360px] rounded-xl border border-gray-200 bg-white p-5 shadow-xl">

--- a/src/features/nodes/TextUpdateNode.tsx
+++ b/src/features/nodes/TextUpdateNode.tsx
@@ -37,6 +37,7 @@ export type NodeData = {
   textColor?: string; // 텍스트 색상
   isMain?: boolean; // 중심 노드인지 서브 노드인지 구분
   sideRelativeToParent?: "left" | "right";
+  handleSide?: "left" | "right"; // Canvas가 위치 변경마다 재계산하는 핸들 방향
   hasParent?: boolean; // 부모 노드 존재 여부
   showInputBox?: boolean; // 입력박스 표시 여부
   isHovered?: boolean; // 드래그 중 hover 상태
@@ -49,8 +50,12 @@ export function TextUpdaterNode({ data, id }: NodeProps) {
   const nodeData = data as NodeData;
   const isMain = nodeData.isMain ?? false;
   const hasParent = nodeData.hasParent ?? true; // 기본값은 부모가 있다고 가정
-  const sideRelativeToParent = nodeData.sideRelativeToParent ?? "right";
-  const sourceHandlePosition = sideRelativeToParent === "left" ? Position.Left : Position.Right;
+  // sideRelativeToParent는 최초 생성 시점에만 설정되므로 handleSide를 사용
+  const sideRelativeToParent = (nodeData.handleSide ??
+    nodeData.sideRelativeToParent ??
+    "right") as "left" | "right";
+  const sourceHandlePosition =
+    sideRelativeToParent === "left" ? Position.Left : Position.Right;
   const showInputBox = nodeData.showInputBox ?? false;
   const isHovered = nodeData.isHovered ?? false;
   const [isNodeHovered, setIsNodeHovered] = useState(false);
@@ -157,9 +162,21 @@ export function TextUpdaterNode({ data, id }: NodeProps) {
               style={{ opacity: isNodeHovered ? 1 : 0 }}
             />
             <Handle
+              type="target"
+              position={Position.Left}
+              id="target-left"
+              style={{ opacity: isNodeHovered ? 1 : 0 }}
+            />
+            <Handle
               type="source"
               position={Position.Right}
               id="source-right"
+              style={{ opacity: isNodeHovered ? 1 : 0 }}
+            />
+            <Handle
+              type="target"
+              position={Position.Right}
+              id="target-right"
               style={{ opacity: isNodeHovered ? 1 : 0 }}
             />
           </>
@@ -167,8 +184,16 @@ export function TextUpdaterNode({ data, id }: NodeProps) {
           <>
             <Handle
               type="target"
-              position={sideRelativeToParent === "right" ? Position.Left : Position.Right}
-              id={sideRelativeToParent === "right" ? "target-left" : "target-right"}
+              position={
+                sideRelativeToParent === "right"
+                  ? Position.Left
+                  : Position.Right
+              }
+              id={
+                sideRelativeToParent === "right"
+                  ? "target-left"
+                  : "target-right"
+              }
               style={{ opacity: isNodeHovered ? 1 : 0 }}
             />
             <Handle


### PR DESCRIPTION
- resolveHandleId: target 핸들은 source 반대 방향으로 수정 (target-right/left 불일치 해소)
- createEdge 호출 3곳: target-\${side} → target-\${반대 side} 로 DB에 저장하는 Edge 데이터 구조 수정
- onConnect swap 조건: standalone 여부만 확인 → 둘 중 하나에서 main 노드 포함 여부로 변경
- getGraphColor: 기본 색상 노드 필터링 누락 수정 (isCustomColorNode 활용)
- NodeData 타입(서버 통신 DTO아닌 UI 전용 필드)에 누락되었던 handleSide 필드 추가
- 부모 노드 기준 자식 노드의 위치(좌/우) 구하는 함수 중 getHandleSide 제거 후 getTargetSideRelativeToParent로 통합
- 자식 노드의 위치 side 변수 → sideRelativeToParent 리네이밍
- getEdgeSide → getTargetSideRelativeToParent 리네이밍