### PR TITLE
Feat : YJS Awareness FE 추가

### DIFF
--- a/src/api/ws.ts
+++ b/src/api/ws.ts
@@ -115,3 +115,27 @@ export function onCursorLeave(
     socket?.off('cursor_leave', handler);
   };
 }
+
+// ─── Workspace Awareness (YJS) ──────────────────────────────────────
+
+export interface WsAwarenessPayload {
+  workspaceId: string;
+  data: ArrayLike<number>;
+}
+
+export function emitWsAwareness(
+  workspaceId: string,
+  data: Uint8Array,
+): void {
+  socket?.emit('yjs:ws:awareness', { workspaceId, data });
+}
+
+export function onWsAwareness(
+  handler: (payload: WsAwarenessPayload) => void,
+): () => void {
+  if (!socket) return () => {};
+  socket.on('yjs:ws:awareness', handler);
+  return () => {
+    socket?.off('yjs:ws:awareness', handler);
+  };
+}

--- a/src/app/graph/context.tsx
+++ b/src/app/graph/context.tsx
@@ -11,7 +11,7 @@ import {
   type SetStateAction,
 } from "react";
 import type { Edge, Node } from "@xyflow/react";
-import type { UserMeResponse } from "@/api/types";
+import type { UserMeResponse, WorkspaceRole } from "@/api/types";
 
 interface GraphLayoutContextValue {
   // 유저
@@ -22,9 +22,12 @@ interface GraphLayoutContextValue {
   setFocusedNodeId: (id: string | null) => void;
   sidebarWidth: number;
   setSidebarWidth: (w: number) => void;
-  // 그래프 데이터 (페이지 이동 시 유지)
+  // 워크스페이스
   workspaceId: string | null;
   setWorkspaceId: Dispatch<SetStateAction<string | null>>;
+  workspaceRole: WorkspaceRole | null;
+  setWorkspaceRole: Dispatch<SetStateAction<WorkspaceRole | null>>;
+  // 그래프 데이터 (페이지 이동 시 유지)
   nodes: Node[];
   setNodes: Dispatch<SetStateAction<Node[]>>;
   edges: Edge[];
@@ -43,6 +46,7 @@ export function GraphLayoutProvider({ children }: { children: ReactNode }) {
   const [focusedNodeId, setFocusedNodeId] = useState<string | null>(null);
   const [sidebarWidth, setSidebarWidth] = useState(0);
   const [workspaceId, setWorkspaceId] = useState<string | null>(null);
+  const [workspaceRole, setWorkspaceRole] = useState<WorkspaceRole | null>(null);
   const [nodes, setNodes] = useState<Node[]>([]);
   const [edges, setEdges] = useState<Edge[]>([]);
   const [synced, setSynced] = useState(false);
@@ -57,6 +61,7 @@ export function GraphLayoutProvider({ children }: { children: ReactNode }) {
         focusedNodeId, setFocusedNodeId,
         sidebarWidth, setSidebarWidth,
         workspaceId, setWorkspaceId,
+        workspaceRole, setWorkspaceRole,
         nodes, setNodes,
         edges, setEdges,
         edgesRef,

--- a/src/app/graph/layout.tsx
+++ b/src/app/graph/layout.tsx
@@ -73,6 +73,7 @@ function GraphLayoutInner({ children }: { children: ReactNode }) {
     setSidebarWidth,
     workspaceId,
     setWorkspaceId,
+    setWorkspaceRole,
     setNodes,
     setEdges,
     nodes,
@@ -125,9 +126,10 @@ function GraphLayoutInner({ children }: { children: ReactNode }) {
     getWorkspaces()
       .then((list) => {
         if (!list.length) return;
-        const id = list[0].workspaceId;
-        setWorkspaceId(id);
-        return getNodes(id);
+        const ws = list[0];
+        setWorkspaceId(ws.workspaceId);
+        setWorkspaceRole(ws.role);
+        return getNodes(ws.workspaceId);
       })
       .then((data) => {
         if (!data) return;

--- a/src/app/graph/node/[nodeId]/page.tsx
+++ b/src/app/graph/node/[nodeId]/page.tsx
@@ -6,6 +6,7 @@ import { NodeEditorPanel } from "@/features/editor/NodeEditorPanel";
 import { getNode } from "@/features/graph/api/nodes";
 import { useGraphLayout } from "@/app/graph/context";
 import { useYjsProvider } from "@/hooks/useYjsProvider";
+import { useWorkspaceAwareness } from "@/hooks/useWorkspaceAwareness";
 import { COLOR_PALETTE } from "@/features/graph/constants/colors";
 
 function getUserCursorColor(userId: string): string {
@@ -22,7 +23,7 @@ export default function NodeFullscreenPage() {
   const params = useParams<{ nodeId: string }>();
   const searchParams = useSearchParams();
 
-  const { sidebarWidth, userMe } = useGraphLayout();
+  const { sidebarWidth, userMe, workspaceRole } = useGraphLayout();
   const nodeId = params.nodeId;
   const workspaceId = searchParams.get("workspaceId") ?? "";
 
@@ -38,6 +39,21 @@ export default function NodeFullscreenPage() {
     userName,
     userColor: cursorColor,
   });
+
+  // 워크스페이스 awareness — 전체화면 에디터에서도 "이 노드를 보는 중" 상태 전파
+  const { setFocusedNodeId } = useWorkspaceAwareness({
+    workspaceId,
+    userName,
+    userColor: cursorColor,
+    role: workspaceRole ?? 'VIEWER',
+  });
+
+  useEffect(() => {
+    if (!loading && !error && nodeId) {
+      setFocusedNodeId(nodeId);
+    }
+    return () => setFocusedNodeId(null);
+  }, [nodeId, loading, error, setFocusedNodeId]);
 
   useEffect(() => {
     if (!workspaceId || !nodeId) return;

--- a/src/app/graph/page.tsx
+++ b/src/app/graph/page.tsx
@@ -8,6 +8,7 @@ export default function GraphPage() {
     focusedNodeId, setFocusedNodeId,
     userMe,
     workspaceId,
+    workspaceRole,
     nodes, setNodes,
     edges, setEdges,
     synced,
@@ -29,6 +30,7 @@ export default function GraphPage() {
       workspaceId={workspaceId}
       currentUserId={currentUserId}
       currentUserName={currentUserName}
+      currentUserRole={workspaceRole ?? 'VIEWER'}
       focusedNodeId={focusedNodeId}
       onFocusComplete={() => setFocusedNodeId(null)}
       nodes={nodes}

--- a/src/features/editor/NodeEditorPanel.tsx
+++ b/src/features/editor/NodeEditorPanel.tsx
@@ -7,6 +7,9 @@ interface NodeEditorPanelProps {
   nodeId: string;
   fullscreen?: boolean;
   onExpandClick?: () => void;
+  onClose?: () => void;
+  onFocus?: () => void;
+  panelZIndex?: number;
   borderColor?: string;
   handleSide?: "left" | "right";
   collabProvider: SocketIoYjsProvider | null;
@@ -19,6 +22,9 @@ export function NodeEditorPanel({
   nodeId,
   fullscreen = false,
   onExpandClick,
+  onClose,
+  onFocus,
+  panelZIndex,
   borderColor = "#D9D9D9",
   handleSide = "right",
   collabProvider,
@@ -58,11 +64,31 @@ export function NodeEditorPanel({
         marginTop: "4px",
         borderColor,
         ...(handleSide === "left" ? { right: 0 } : { left: 0 }),
-        zIndex: 0,
+        zIndex: panelZIndex ?? 0,
       }}
       onClick={(e) => e.stopPropagation()}
-      onMouseDown={(e) => e.stopPropagation()}
+      onMouseDown={(e) => {
+        e.stopPropagation();
+        onFocus?.();
+      }}
     >
+      {/* 닫기 버튼 */}
+      {onClose && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onClose();
+          }}
+          className="absolute top-1 right-1 z-10 flex items-center justify-center rounded hover:bg-gray-100 transition-colors"
+          style={{ width: 22, height: 22 }}
+          title="닫기"
+        >
+          <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="#999" strokeWidth="1.5" strokeLinecap="round">
+            <path d="M1 1L9 9M9 1L1 9" />
+          </svg>
+        </button>
+      )}
       {!collabProvider ? (
         <div className="flex items-center justify-center h-full text-gray-400 text-sm">
           워크스페이스를 불러오는 중...

--- a/src/features/graph/components/GraphCanvas.tsx
+++ b/src/features/graph/components/GraphCanvas.tsx
@@ -40,9 +40,10 @@ import { rectCollide } from '../layout/rectCollide';
 import { getRandomColorPair, DEFAULT_NODE_COLOR } from '../constants/colors';
 import { getDescendantIds } from '../utils/graphUtils';
 import { useCursors } from '@/hooks/useCursors';
+import { useWorkspaceAwareness } from '@/hooks/useWorkspaceAwareness';
 import { getCursorColor } from '@/utils/cursorColor';
 import CursorOverlay from './CursorOverlay';
-import { MdBody } from '@/api/types';
+import { MdBody, type WorkspaceRole } from '@/api/types';
 
 // TODO: 실제 노드 너비로 변경
 const NODE_WIDTH = 200;
@@ -552,6 +553,7 @@ interface GraphCanvasInnerProps {
   workspaceId: string;
   currentUserId: string;
   currentUserName: string;
+  currentUserRole: WorkspaceRole;
   focusedNodeId: string | null;
   onFocusComplete?: () => void;
   nodes: Node[];
@@ -618,6 +620,7 @@ function GraphCanvasInner({
   workspaceId,
   currentUserId,
   currentUserName,
+  currentUserRole,
   focusedNodeId,
   onFocusComplete,
   nodes,
@@ -625,7 +628,8 @@ function GraphCanvasInner({
   setNodes,
   setEdges,
 }: GraphCanvasInnerProps) {
-  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [openNodeIds, setOpenNodeIds] = useState<string[]>([]);
+  const [localFocusedNodeId, setLocalFocusedNodeId] = useState<string | null>(null);
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
   const [isArchiveModalOpen, setIsArchiveModalOpen] = useState(false);
   const [pendingArchiveNodeIds, setPendingArchiveNodeIds] = useState<string[]>(
@@ -633,6 +637,33 @@ function GraphCanvasInner({
   );
 
   const { screenToFlowPosition, setCenter } = useReactFlow();
+
+  // ─── Workspace Awareness ─────────────────────────────────────────
+  const cursorColor = getCursorColor(currentUserId);
+
+  // Remote toggle: only open (add to openNodeIds + focus), never close
+  const handleRemoteToggle = useCallback(
+    (event: { nodeId: string | null; isOpen: boolean }) => {
+      if (!event.isOpen || !event.nodeId) return;
+      const nodeId = event.nodeId;
+      setOpenNodeIds((prev) => (prev.includes(nodeId) ? prev : [...prev, nodeId]));
+      setLocalFocusedNodeId(nodeId);
+    },
+    [],
+  );
+
+  const { nodeViewers, setFocusedNodeId } = useWorkspaceAwareness({
+    workspaceId,
+    userName: currentUserName,
+    userColor: cursorColor,
+    role: currentUserRole,
+    onRemoteToggle: handleRemoteToggle,
+  });
+
+  // Sync localFocusedNodeId → awareness
+  useEffect(() => {
+    setFocusedNodeId(localFocusedNodeId);
+  }, [localFocusedNodeId, setFocusedNodeId]);
 
   // viewport 저장 (debounce)
   const viewportSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -686,7 +717,6 @@ function GraphCanvasInner({
   >(null);
   const lastCursorEmitRef = useRef(0);
   const CURSOR_EMIT_INTERVAL = 30; // ms
-  const cursorColor = getCursorColor(currentUserId);
 
   // 타인 커서 + 본인 커서 합산
   const cursors = selfCursor
@@ -821,6 +851,15 @@ function GraphCanvasInner({
     new Map(),
   );
 
+  const handleClosePanel = useCallback((nodeId: string) => {
+    setOpenNodeIds((prev) => prev.filter((id) => id !== nodeId));
+    setLocalFocusedNodeId((prev) => (prev === nodeId ? null : prev));
+  }, []);
+
+  const handleFocusPanel = useCallback((nodeId: string) => {
+    setLocalFocusedNodeId(nodeId);
+  }, []);
+
   const handleTitleChange = useCallback(
     (nodeId: string, value: string) => {
       handleNodeViewChange(nodeId, { title: value });
@@ -861,9 +900,13 @@ function GraphCanvasInner({
           ? undefined
           : getTargetSideRelativeToParent(node.position.x, referenceX),
         hasParent, // 부모 노드 존재 여부 전달
-        showInputBox: selectedNodeId === node.id, // 선택된 노드에만 입력박스 표시
+        showInputBox: openNodeIds.includes(node.id), // 열린 노드에 입력박스 표시
+        panelZIndex: node.id === localFocusedNodeId ? 30 : 20, // 포커스된 패널이 위
         isHovered: hoveredNodeId === node.id, // 드래그 중 hover된 노드 표시
         workspaceId, // 전체화면 이동 시 사용
+        viewers: nodeViewers[node.id] ?? [], // 현재 이 노드를 보고 있는 다른 유저들
+        onClosePanel: handleClosePanel,
+        onFocusPanel: handleFocusPanel,
         onChange: handleTitleChange,
       },
     };
@@ -884,7 +927,6 @@ function GraphCanvasInner({
 
       setPendingArchiveNodeIds(Array.from(subtreeNodeIds));
       setIsArchiveModalOpen(true);
-      setSelectedNodeId(null);
     },
     [edges],
   );
@@ -958,7 +1000,8 @@ function GraphCanvasInner({
       snapshot.filter((node) => !idsToArchive.has(node.id)),
     );
     setHoveredNodeId((prev) => (prev && idsToArchive.has(prev) ? null : prev));
-    setSelectedNodeId((prev) => (prev && idsToArchive.has(prev) ? null : prev));
+    setOpenNodeIds((prev) => prev.filter((id) => !idsToArchive.has(id)));
+    setLocalFocusedNodeId((prev) => (prev && idsToArchive.has(prev) ? null : prev));
     setPendingArchiveNodeIds([]);
     setIsArchiveModalOpen(false);
   }, [pendingArchiveNodeIds, workspaceId]);
@@ -1383,9 +1426,14 @@ function GraphCanvasInner({
      Node click → toggle input box
      ========================= */
   const onNodeClick = useCallback((event: React.MouseEvent, node: Node) => {
-    console.log('[onNodeClick] node.data', node.data);
-    // 같은 노드를 다시 클릭하면 닫기 (토글)
-    setSelectedNodeId((prev) => (prev === node.id ? null : node.id));
+    setOpenNodeIds((prev) => {
+      if (prev.includes(node.id)) {
+        // 이미 열려 있으면 포커스만 이동
+        return prev;
+      }
+      return [...prev, node.id];
+    });
+    setLocalFocusedNodeId(node.id);
   }, []);
 
   /* =========================
@@ -1396,9 +1444,10 @@ function GraphCanvasInner({
       // 연결 드래그 중이면 노드 생성하지 않음
       if (isConnectingRef.current) return;
 
-      // 입력박스가 열려 있으면 우선 닫고, 같은 클릭으로 노드 생성은 하지 않음
-      if (selectedNodeId !== null) {
-        setSelectedNodeId(null);
+      // 패널이 열려 있으면 우선 모두 닫고, 같은 클릭으로 노드 생성은 하지 않음
+      if (openNodeIds.length > 0) {
+        setOpenNodeIds([]);
+        setLocalFocusedNodeId(null);
         return;
       }
 
@@ -1442,7 +1491,7 @@ function GraphCanvasInner({
         console.error('[onPaneClick] createMdNode failed', err);
       }
     },
-    [screenToFlowPosition, selectedNodeId, workspaceId],
+    [screenToFlowPosition, openNodeIds, workspaceId],
   );
 
   const onDragOver = useCallback(
@@ -2078,6 +2127,7 @@ interface GraphCanvasProps {
   workspaceId: string;
   currentUserId: string;
   currentUserName: string;
+  currentUserRole: WorkspaceRole;
   focusedNodeId?: string | null;
   onFocusComplete?: () => void;
   nodes: Node[];
@@ -2090,6 +2140,7 @@ export default function GraphCanvas({
   workspaceId,
   currentUserId,
   currentUserName,
+  currentUserRole,
   focusedNodeId = null,
   onFocusComplete,
   nodes,
@@ -2103,6 +2154,7 @@ export default function GraphCanvas({
         workspaceId={workspaceId}
         currentUserId={currentUserId}
         currentUserName={currentUserName}
+        currentUserRole={currentUserRole}
         focusedNodeId={focusedNodeId}
         onFocusComplete={onFocusComplete}
         nodes={nodes}

--- a/src/features/nodes/TextUpdateNode.tsx
+++ b/src/features/nodes/TextUpdateNode.tsx
@@ -23,6 +23,12 @@ function getUserCursorColor(userId: string): string {
   return COLOR_PALETTE[Math.abs(hash) % COLOR_PALETTE.length].text;
 }
 
+export interface NodeViewer {
+  clientId: number;
+  name: string;
+  color: string;
+}
+
 export type NodeView = {
   title?: string;
   color?: string;
@@ -32,8 +38,12 @@ export type NodeView = {
   handleSide?: 'left' | 'right'; // Canvas가 위치 변경마다 재계산하는 핸들 방향
   hasParent?: boolean; // 부모 노드 존재 여부
   showInputBox?: boolean; // 입력박스 표시 여부
+  panelZIndex?: number; // 패널 z-index (포커스된 패널이 위)
   isHovered?: boolean; // 드래그 중 hover 상태
   workspaceId?: string; // 전체화면 이동 시 query param으로 사용
+  viewers?: NodeViewer[]; // 이 노드를 보고 있는 다른 유저들
+  onClosePanel?: (nodeId: string) => void; // 패널 닫기
+  onFocusPanel?: (nodeId: string) => void; // 패널 포커스
   onChange?: (nodeId: string, value: string) => void;
 };
 
@@ -61,6 +71,7 @@ export function TextUpdaterNode({ data, id }: NodeProps) {
     'right') as 'left' | 'right';
   const sourceHandlePosition =
     sideRelativeToParent === 'left' ? Position.Left : Position.Right;
+  const viewers = (nodeData.viewers ?? []) as NodeViewer[];
   const isHovered = nodeData.isHovered ?? false;
   const [isNodeHovered, setIsNodeHovered] = useState(false);
 
@@ -86,30 +97,90 @@ export function TextUpdaterNode({ data, id }: NodeProps) {
   // React Flow 기본 엣지 색상과 동일한 회색 (#b1b1b7)
   const EDGE_COLOR = '#D9D9D9';
 
+  const viewerBorderColor = viewers.length > 0 ? viewers[0].color : null;
+
   const containerStyle = isMain
     ? {
         backgroundColor: nodeData.color || '#ffffff',
-        borderColor: isHovered ? '#93C5FD' : EDGE_COLOR,
-        borderWidth: isHovered ? '3px' : '1px',
+        borderColor: isHovered
+          ? '#93C5FD'
+          : viewerBorderColor ?? EDGE_COLOR,
+        borderWidth: isHovered || viewerBorderColor ? '2px' : '1px',
       }
     : {
         backgroundColor: nodeData.color || '#ffffff',
-        border: isHovered ? '3px solid #93C5FD' : 'none', // hover 시 연한 파란색 테두리
+        border: isHovered
+          ? '3px solid #93C5FD'
+          : viewerBorderColor
+            ? `2px solid ${viewerBorderColor}`
+            : 'none',
       };
+
+  // 최대 3명 표시, 이후 +N
+  const visibleViewers = viewers.slice(0, 3);
+  const overflowCount = viewers.length - visibleViewers.length;
 
   return (
     <div className="relative">
+      {/* 다른 유저 뷰어 표시 — 노드 위에 배치 */}
+      {viewers.length > 0 && (
+        <div
+          className="absolute flex items-center gap-0.5"
+          style={{
+            bottom: '100%',
+            left: '50%',
+            transform: 'translateX(-50%)',
+            marginBottom: 4,
+            zIndex: 20,
+            pointerEvents: 'none',
+          }}
+        >
+          {visibleViewers.map((v) => (
+            <div
+              key={v.clientId}
+              title={v.name}
+              className="flex items-center justify-center rounded-full text-white text-[9px] font-bold leading-none select-none"
+              style={{
+                width: 20,
+                height: 20,
+                backgroundColor: v.color,
+                border: '2px solid white',
+                marginLeft: visibleViewers.indexOf(v) > 0 ? -4 : 0,
+              }}
+            >
+              {v.name.charAt(0).toUpperCase()}
+            </div>
+          ))}
+          {overflowCount > 0 && (
+            <div
+              className="flex items-center justify-center rounded-full bg-gray-400 text-white text-[8px] font-bold leading-none select-none"
+              style={{
+                width: 20,
+                height: 20,
+                border: '2px solid white',
+                marginLeft: -4,
+              }}
+            >
+              +{overflowCount}
+            </div>
+          )}
+        </div>
+      )}
+
       {/* 노션 에디터 패널 - 노드 뒤에 배치 */}
       {showInputBox && (
         <NodeEditorPanel
           nodeId={id}
           borderColor={EDGE_COLOR}
           handleSide={sideRelativeToParent}
+          panelZIndex={nodeData.panelZIndex}
           onExpandClick={() =>
             router.push(
               `/graph/node/${id}?workspaceId=${nodeData.workspaceId ?? ''}`,
             )
           }
+          onClose={() => nodeData.onClosePanel?.(id)}
+          onFocus={() => nodeData.onFocusPanel?.(id)}
           collabProvider={collabProvider}
           username={userName}
           cursorColor={cursorColor}

--- a/src/hooks/useWorkspaceAwareness.ts
+++ b/src/hooks/useWorkspaceAwareness.ts
@@ -1,0 +1,210 @@
+'use client';
+
+import { useEffect, useRef, useState, useCallback } from 'react';
+import * as Y from 'yjs';
+import * as awarenessProtocol from 'y-protocols/awareness';
+import { emitWsAwareness, onWsAwareness } from '@/api/ws';
+import type { WorkspaceRole } from '@/api/types';
+
+// ─── Types ──────────────────────────────────────────────────────────
+
+export interface AwarenessUserState {
+  focusedNodeId: string | null;
+  isOpen: boolean;
+  user: {
+    name: string;
+    color: string;
+    role: WorkspaceRole;
+  };
+}
+
+/** nodeId → list of remote viewers */
+export type NodeViewersMap = Record<
+  string,
+  { clientId: number; name: string; color: string }[]
+>;
+
+/** Remote toggle event emitted by OWNER/EDITOR */
+export interface RemoteToggleEvent {
+  nodeId: string | null;
+  isOpen: boolean;
+}
+
+// ─── Hook ───────────────────────────────────────────────────────────
+
+interface UseWorkspaceAwarenessOptions {
+  workspaceId: string;
+  userName: string;
+  userColor: string;
+  role: WorkspaceRole;
+  /** Called when a remote OWNER/EDITOR toggles a node open/closed */
+  onRemoteToggle?: (event: RemoteToggleEvent) => void;
+}
+
+export function useWorkspaceAwareness({
+  workspaceId,
+  userName,
+  userColor,
+  role,
+  onRemoteToggle,
+}: UseWorkspaceAwarenessOptions) {
+  const docRef = useRef<Y.Doc | null>(null);
+  const awarenessRef = useRef<awarenessProtocol.Awareness | null>(null);
+  const refreshTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const onRemoteToggleRef = useRef(onRemoteToggle);
+  onRemoteToggleRef.current = onRemoteToggle;
+
+  const [nodeViewers, setNodeViewers] = useState<NodeViewersMap>({});
+
+  // ── Build viewers map from awareness states ──
+
+  const rebuildViewers = useCallback(
+    (awareness: awarenessProtocol.Awareness) => {
+      const map: NodeViewersMap = {};
+      awareness.getStates().forEach((state, clientId) => {
+        if (clientId === awareness.clientID) return;
+        const s = state as AwarenessUserState;
+        if (!s.focusedNodeId || !s.user) return;
+        const entry = { clientId, name: s.user.name, color: s.user.color };
+        if (!map[s.focusedNodeId]) {
+          map[s.focusedNodeId] = [entry];
+        } else {
+          map[s.focusedNodeId].push(entry);
+        }
+      });
+      setNodeViewers(map);
+    },
+    [],
+  );
+
+  // ── Lifecycle: create doc/awareness, subscribe to socket ──
+
+  useEffect(() => {
+    if (!workspaceId) return;
+
+    const doc = new Y.Doc();
+    const awareness = new awarenessProtocol.Awareness(doc);
+    docRef.current = doc;
+    awarenessRef.current = awareness;
+
+    // Set initial local state
+    awareness.setLocalStateField('focusedNodeId', null);
+    awareness.setLocalStateField('isOpen', false);
+    awareness.setLocalStateField('user', {
+      name: userName,
+      color: userColor,
+      role,
+    });
+
+    // Listen for remote awareness updates from server
+    const cleanupSocket = onWsAwareness(({ data }) => {
+      awarenessProtocol.applyAwarenessUpdate(
+        awareness,
+        new Uint8Array(data),
+        null,
+      );
+    });
+
+    // Handle awareness changes — rebuild viewers + detect remote toggles
+    const handleChange = (
+      changes: { added: number[]; updated: number[]; removed: number[] },
+    ) => {
+      rebuildViewers(awareness);
+
+      // Detect remote toggle events
+      const changedIds = [...changes.added, ...changes.updated];
+      for (const clientId of changedIds) {
+        if (clientId === awareness.clientID) continue;
+        const state = awareness.getStates().get(clientId) as
+          | AwarenessUserState
+          | undefined;
+        if (!state?.user) continue;
+        onRemoteToggleRef.current?.({
+          nodeId: state.focusedNodeId,
+          isOpen: state.isOpen,
+        });
+      }
+    };
+    awareness.on('change', handleChange);
+
+    // Emit current state on connect
+    const update = awarenessProtocol.encodeAwarenessUpdate(awareness, [
+      awareness.clientID,
+    ]);
+    emitWsAwareness(workspaceId, update);
+
+    // 15-second TTL refresh
+    refreshTimerRef.current = setInterval(() => {
+      const a = awarenessRef.current;
+      if (!a) return;
+      const u = awarenessProtocol.encodeAwarenessUpdate(a, [a.clientID]);
+      emitWsAwareness(workspaceId, u);
+    }, 15_000);
+
+    return () => {
+      if (refreshTimerRef.current) {
+        clearInterval(refreshTimerRef.current);
+        refreshTimerRef.current = null;
+      }
+      cleanupSocket();
+      awareness.off('change', handleChange);
+      awarenessProtocol.removeAwarenessStates(
+        awareness,
+        [awareness.clientID],
+        'window unload',
+      );
+      awareness.destroy();
+      doc.destroy();
+      docRef.current = null;
+      awarenessRef.current = null;
+      setNodeViewers({});
+    };
+  }, [workspaceId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── Keep user info in sync ──
+
+  useEffect(() => {
+    awarenessRef.current?.setLocalStateField('user', {
+      name: userName,
+      color: userColor,
+      role,
+    });
+  }, [userName, userColor, role]);
+
+  // ── Emit helper ──
+
+  const emitLocal = useCallback(
+    (awareness: awarenessProtocol.Awareness) => {
+      const update = awarenessProtocol.encodeAwarenessUpdate(awareness, [
+        awareness.clientID,
+      ]);
+      emitWsAwareness(workspaceId, update);
+    },
+    [workspaceId],
+  );
+
+  // ── Public: set focused node + open state ──
+
+  const setFocusedNodeId = useCallback(
+    (nodeId: string | null) => {
+      const awareness = awarenessRef.current;
+      if (!awareness) return;
+      awareness.setLocalStateField('focusedNodeId', nodeId);
+      awareness.setLocalStateField('isOpen', nodeId !== null);
+      emitLocal(awareness);
+    },
+    [emitLocal],
+  );
+
+  const setIsOpen = useCallback(
+    (isOpen: boolean) => {
+      const awareness = awarenessRef.current;
+      if (!awareness) return;
+      awareness.setLocalStateField('isOpen', isOpen);
+      emitLocal(awareness);
+    },
+    [emitLocal],
+  );
+
+  return { nodeViewers, setFocusedNodeId, setIsOpen };
+}


### PR DESCRIPTION
## 요약

워크스페이스 레벨 YJS Awareness를 FE에 연동하여 실시간 노드 뷰어 표시 + 에디터 패널 열기/닫기 전파 + 멀티 패널 동시 오픈을 구현.

## 변경 파일 (9개, +479 / -96)

| 파일 | 변경 내용 |
|------|-----------|
| `src/hooks/useWorkspaceAwareness.ts` | **신규** — 워크스페이스 레벨 Y.Doc + Awareness 훅. 15초 TTL 갱신, remote state 수신, `nodeViewers` 맵 반환, `onRemoteToggle` 콜백 |
| `src/api/ws.ts` | `emitWsAwareness()`, `onWsAwareness()` 헬퍼 추가 (`yjs:ws:awareness` 이벤트) |
| `src/features/graph/components/GraphCanvas.tsx` | `selectedNodeId` → `openNodeIds[]` + `localFocusedNodeId`로 멀티 패널 지원. awareness 훅 연동, `handleClosePanel`/`handleFocusPanel` 추가, 노드 data에 `viewers`/`panelZIndex`/`onClosePanel`/`onFocusPanel` 전달 |
| `src/features/nodes/TextUpdateNode.tsx` | `NodeView`에 `panelZIndex`, `viewers`, `onClosePanel`, `onFocusPanel` 추가. 노드 상단 뷰어 아바타 렌더링 + 뷰어 테두리 색상 |
| `src/features/editor/NodeEditorPanel.tsx` | `onClose`, `onFocus`, `panelZIndex` props 추가. 닫기(X) 버튼, 클릭 시 포커스, 동적 z-index |
| `src/app/graph/context.tsx` | `workspaceRole` / `setWorkspaceRole` context 필드 추가 |
| `src/app/graph/layout.tsx` | `getWorkspaces()` 결과에서 `role` 추출하여 context에 저장 |
| `src/app/graph/page.tsx` | `workspaceRole` context에서 가져와 `GraphCanvas`에 `currentUserRole` 전달 |
| `src/app/graph/node/[nodeId]/page.tsx` | 전체화면 에디터에서도 awareness emit (해당 노드 뷰어 상태 전파) |

## 주요 기능

### 1. 실시간 뷰어 표시

- 다른 유저가 노드 에디터를 열면 해당 노드 위에 이니셜 아바타 표시 (최대 3명 + overflow)
- 노드 테두리 색상이 뷰어 색상으로 변경

### 2. 에디터 패널 열기/닫기 전파

- 유저 A가 노드 클릭 → awareness emit → 유저 B 화면에서 해당 노드 패널 자동 오픈
- 닫기도 동일하게 전파

### 3. 멀티 패널 동시 오픈

- `selectedNodeId: string | null` → `openNodeIds: string[]` 마이그레이션
- 여러 노드 패널 동시 열기 가능, z-index 스택으로 포커스 관리
- 각 패널에 닫기(X) 버튼 추가
- 빈 캔버스 클릭 시 전체 닫기

### 4. 워크스페이스 Role 전파

- `getWorkspaces()` 응답의 `role`을 context에 저장
- awareness state에 `user.role` 포함

## BE 의존성

- `yjs:ws:awareness` 이벤트 — BE `ws.gateway.ts`에서 awareness broadcast 구현 필요
- `join_workspace` 시 서버가 awareness 룸 자동 조인 (별도 join 불필요)
- 서버 30초 TTL → FE 15초 갱신으로 대응
