### PR TITLE
feat: 전체화면/닫기 버튼 UI 개선

### DIFF
--- a/src/features/editor/NodeEditorPanel.tsx
+++ b/src/features/editor/NodeEditorPanel.tsx
@@ -72,23 +72,41 @@ export function NodeEditorPanel({
         onFocus?.();
       }}
     >
-      {/* 닫기 버튼 */}
-      {onClose && (
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onClose();
-          }}
-          className="absolute top-1 right-1 z-10 flex items-center justify-center rounded hover:bg-gray-100 transition-colors"
-          style={{ width: 22, height: 22 }}
-          title="닫기"
-        >
-          <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="#999" strokeWidth="1.5" strokeLinecap="round">
-            <path d="M1 1L9 9M9 1L1 9" />
-          </svg>
-        </button>
-      )}
+      {/* 전체화면 / 닫기 버튼 */}
+      <div className="absolute top-1 right-1 z-10 flex items-center gap-0.5">
+        {onExpandClick && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onExpandClick();
+            }}
+            className="flex items-center justify-center rounded hover:bg-gray-100 transition-colors"
+            style={{ width: 22, height: 22 }}
+            title="전체화면으로 보기"
+          >
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="#858585" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M1 11L11 1M8 1H11V4M4 11H1V8" />
+            </svg>
+          </button>
+        )}
+        {onClose && (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onClose();
+            }}
+            className="flex items-center justify-center rounded hover:bg-gray-100 transition-colors"
+            style={{ width: 22, height: 22 }}
+            title="닫기"
+          >
+            <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="#858585" strokeWidth="1.5" strokeLinecap="round">
+              <path d="M1 1L9 9M9 1L1 9" />
+            </svg>
+          </button>
+        )}
+      </div>
       {!collabProvider ? (
         <div className="flex items-center justify-center h-full text-gray-400 text-sm">
           워크스페이스를 불러오는 중...
@@ -96,7 +114,6 @@ export function NodeEditorPanel({
       ) : (
         <NotionEditor
           nodeId={nodeId}
-          onFullscreen={onExpandClick}
           collabProvider={collabProvider}
           username={username}
           cursorColor={cursorColor}

--- a/src/features/editor/NotionEditor.tsx
+++ b/src/features/editor/NotionEditor.tsx
@@ -71,7 +71,6 @@ type BlockType =
 
 export interface NotionEditorProps {
   nodeId: string;
-  onFullscreen?: () => void;
   collabProvider: SocketIoYjsProvider | null;
   username?: string;
   cursorColor?: string;
@@ -192,13 +191,7 @@ const BLOCK_OPTIONS = [
 
 // ─── Toolbar Plugin ───────────────────────────────────────────────────────────
 
-function ToolbarPlugin({
-  onFullscreen,
-}: {
-  showDebug?: boolean;
-  onDebugToggle?: () => void;
-  onFullscreen?: () => void;
-}) {
+function ToolbarPlugin() {
   const [editor] = useLexicalComposerContext();
   const [isBold, setIsBold] = useState(false);
   const [isItalic, setIsItalic] = useState(false);
@@ -450,32 +443,6 @@ function ToolbarPlugin({
         </button>
       ))}
 
-      {/* ── Fullscreen toggle ── */}
-      {onFullscreen && (
-        <div style={{ marginLeft: "auto" }}>
-          <button
-            type="button"
-            title="전체화면으로 보기"
-            onClick={onFullscreen}
-            onMouseDown={(e) => e.preventDefault()}
-            className="flex items-center justify-center rounded cursor-pointer transition-colors hover:bg-[#F3F3F3]"
-            style={{ width: 26, height: 26 }}
-          >
-            <svg
-              width="12"
-              height="12"
-              viewBox="0 0 12 12"
-              fill="none"
-              stroke="#CCCCCC"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M1 4.5V1H4.5M7.5 1H11V4.5M11 7.5V11H7.5M4.5 11H1V7.5" />
-            </svg>
-          </button>
-        </div>
-      )}
     </div>
   );
 }
@@ -510,7 +477,6 @@ function TitleTrackerPlugin({
 
 export function NotionEditor({
   nodeId,
-  onFullscreen,
   collabProvider,
   username,
   cursorColor,
@@ -541,7 +507,7 @@ export function NotionEditor({
     <div className="flex flex-col flex-1 min-h-0 bg-white rounded-b-lg">
       <LexicalCollaboration>
         <LexicalComposer initialConfig={initialConfig}>
-          <ToolbarPlugin onFullscreen={onFullscreen} />
+          <ToolbarPlugin />
 
         {/* min-h-0: flex child가 컨텐츠 크기 이하로 수축 가능 → overflow-y-auto 작동 */}
         <div className="relative flex-1 min-h-0 overflow-y-auto">


### PR DESCRIPTION
## Summary
- NodeEditorPanel 우측 상단에 expand(↗) → X 순서로 버튼 그룹 통합
- 아이콘 색상 `#999` → `#858585` (Figma GrayScale/400 반영)
- 기존 ToolbarPlugin에 있던 fullscreen 버튼 제거 → NodeEditorPanel로 일원화

## Test plan
- [ ] 노드 클릭 시 패널 우측 상단에 expand 아이콘과 X 버튼이 나란히 표시되는지 확인
- [ ] expand 버튼 클릭 시 전체화면 전환 동작 확인
- [ ] X 버튼 클릭 시 패널 닫힘 확인
- [ ] 텍스트 에디터 툴바에 fullscreen 버튼이 더 이상 표시되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)